### PR TITLE
Add %f formatter to display microseconds

### DIFF
--- a/gostrftime.go
+++ b/gostrftime.go
@@ -31,6 +31,9 @@ func strftime(b *bytes.Buffer, c rune, t time.Time) error {
 	case 'F':
 		y, m, d := t.Date()
 		fmt.Fprintf(b, "%04d-%02d-%02d", y, m, d)
+	case 'f':
+		usec := t.Nanosecond() / 1e3
+		fmt.Fprintf(b, "%06d", int(usec))
 	case 'H':
 		fmt.Fprintf(b, "%02d", t.Hour())
 	case 'h':

--- a/gostrftime_test.go
+++ b/gostrftime_test.go
@@ -45,6 +45,7 @@ var formattests = []struct {
 	{"%d", "02"},
 	{"%e", " 2"},
 	{"%F", "2009-01-02"},
+	{"%f", "000001"},
 	{"%H", "03"},
 	{"%h", "Jan"},
 	{"%I", "03"},
@@ -73,7 +74,7 @@ func TestStrfFormat(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	tm := time.Date(2009, time.January, 2, 3, 4, 0, 0, time.UTC)
+	tm := time.Date(2009, time.January, 2, 3, 4, 0, 1001, time.UTC)
 	for _, tt := range formattests {
 		output := Format(tt.format, tm)
 		assert.Equal(tt.expected, output, fmt.Sprintf("%s not right", tt.format))
@@ -86,7 +87,7 @@ func TestStrfFormatNotUTC(t *testing.T) {
 
 	// use a timezone that doesn't do daylight savings
 	location := time.FixedZone("Saskatchewan", -6*60*60)
-	tm := time.Date(2009, time.January, 2, 3, 4, 0, 0, location)
+	tm := time.Date(2009, time.January, 2, 3, 4, 0, 1001, location)
 	for _, tt := range formattests {
 		var expected string
 		switch tt.format {
@@ -109,7 +110,7 @@ func BenchmarkStrfFormatAll(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		Format("%A %a %B %b %C %D %d %e %F %H %h %I %j %k %l %M %m %n %p %R %r %S %s %T %t %v %w %Y %y %Z %z", tm)
+		Format("%A %a %B %b %C %D %d %e %F %f %H %h %I %j %k %l %M %m %n %p %R %r %S %s %T %t %v %w %Y %y %Z %z", tm)
 	}
 }
 


### PR DESCRIPTION
The %f formatter is borrowed from the Python datetime module. This has been requested by users of the Heka project (a Logstash replacement), see https://github.com/mozilla-services/heka/issues/1691 for details.
